### PR TITLE
Use service name to improve logging output

### DIFF
--- a/logfebe.go
+++ b/logfebe.go
@@ -261,11 +261,9 @@ func emitLogRecord(lr *logRecord, sr *serveRecord, target *logplexc.Client,
 		}
 	}
 
-	if sr.Name != "" {
-		// If available, identify what agent is doing the
-		// logging to aid human readers in determining where a
-		// log message came from.
-		msgFmtBuf.WriteString("[" + sr.Name + "] ")
+	if sr.Prefix != "" {
+		msgFmtBuf.WriteString(sr.Prefix)
+		msgFmtBuf.WriteString(" ")
 	}
 
 	if isAudit {

--- a/serve_db.go
+++ b/serve_db.go
@@ -82,7 +82,6 @@ type serveRecord struct {
 	protocol string
 
 	// Auxiliary fields for formatting
-	Name    string
 	Service string
 	Prefix  string
 }
@@ -434,13 +433,12 @@ func projectFromJSON(v interface{}) (*serveRecord, error) {
 	}
 
 	// Optional fields: okay to not explode if not present.
-	name, _ := lookup("name")
 	service, _ := lookup("service")
 	prefix, _ := lookup("prefix")
 
 	return &serveRecord{sKey: sKey{P: path, I: ident},
 		u: *u, audit: audit, protocol: proto,
-		Name: name, Service: service, Prefix: prefix}, nil
+		Service: service, Prefix: prefix}, nil
 }
 
 func (t *serveDb) parse(contents []byte) (map[sKey]*serveRecord, error) {

--- a/serve_db.go
+++ b/serve_db.go
@@ -82,7 +82,9 @@ type serveRecord struct {
 	protocol string
 
 	// Auxiliary fields for formatting
-	Name string
+	Name    string
+	Service string
+	Prefix  string
 }
 
 type serveDb struct {
@@ -433,9 +435,12 @@ func projectFromJSON(v interface{}) (*serveRecord, error) {
 
 	// Optional fields: okay to not explode if not present.
 	name, _ := lookup("name")
+	service, _ := lookup("service")
+	prefix, _ := lookup("prefix")
 
 	return &serveRecord{sKey: sKey{P: path, I: ident},
-		u: *u, audit: audit, protocol: proto, Name: name}, nil
+		u: *u, audit: audit, protocol: proto,
+		Name: name, Service: service, Prefix: prefix}, nil
 }
 
 func (t *serveDb) parse(contents []byte) (map[sKey]*serveRecord, error) {

--- a/serve_db_test.go
+++ b/serve_db_test.go
@@ -47,12 +47,12 @@ var fixtures = []fixturePair{
 			{sKey{I: "apple", P: "/p1/log.sock"},
 				mustParseURL(
 					"https://token:chocolate@localhost"),
-				nil, "logfebe",
+				nil, "logfebe", "postgres", "[purple-rain-1984]",
 				"brown"},
 			{sKey{I: "banana", P: "/p2/log.sock"},
 				mustParseURL(
 					"https://token:vanilla@localhost"),
-				nil, "logfebe",
+				nil, "logfebe", "postgres", "[purple-rain-1984]",
 				"white"},
 		},
 	},
@@ -68,12 +68,12 @@ var fixtures = []fixturePair{
 			{sKey{I: "bed", P: "/p1/log.sock"},
 				mustParseURL(
 					"https://token:pillow@localhost"),
-				nil, "logfebe",
+				nil, "logfebe", "postgres", "[purple-rain-1984]",
 				"white"},
 			{sKey{I: "nightstand", P: "/p2/log.sock"},
 				mustParseURL(
 					"https://token:alarm-clock@localhost"),
-				nil, "logfebe",
+				nil, "logfebe", "postgres", "[purple-rain-1984]",
 				"black"},
 		},
 	},

--- a/serve_db_test.go
+++ b/serve_db_test.go
@@ -47,13 +47,11 @@ var fixtures = []fixturePair{
 			{sKey{I: "apple", P: "/p1/log.sock"},
 				mustParseURL(
 					"https://token:chocolate@localhost"),
-				nil, "logfebe", "postgres", "[purple-rain-1984]",
-				"brown"},
+				nil, "logfebe", "postgres", "[purple-rain-1984]"},
 			{sKey{I: "banana", P: "/p2/log.sock"},
 				mustParseURL(
 					"https://token:vanilla@localhost"),
-				nil, "logfebe", "postgres", "[purple-rain-1984]",
-				"white"},
+				nil, "logfebe", "postgres", "[purple-rain-1984]"},
 		},
 	},
 	{
@@ -68,13 +66,11 @@ var fixtures = []fixturePair{
 			{sKey{I: "bed", P: "/p1/log.sock"},
 				mustParseURL(
 					"https://token:pillow@localhost"),
-				nil, "logfebe", "postgres", "[purple-rain-1984]",
-				"white"},
+				nil, "logfebe", "postgres", "[purple-rain-1984]"},
 			{sKey{I: "nightstand", P: "/p2/log.sock"},
 				mustParseURL(
 					"https://token:alarm-clock@localhost"),
-				nil, "logfebe", "postgres", "[purple-rain-1984]",
-				"black"},
+				nil, "logfebe", "postgres", "[purple-rain-1984]"},
 		},
 	},
 }


### PR DESCRIPTION
This use the new service config value to allow filtering per service, and also change the redis default formatting to match postgres.

cc/ @uhoh-itsmaciek @kvlou 
